### PR TITLE
Create mcp3008_LDR.py

### DIFF
--- a/mcp3008_LDR.py
+++ b/mcp3008_LDR.py
@@ -1,0 +1,21 @@
+from gpiozero import MCP3008
+from time import sleep
+
+adc_channel = 0
+
+
+light_sensor = MCP3008(channel=adc_channel, clock_pin=11, mosi_pin=10, miso_pin=9, select_pin=5)
+
+print("roading...")
+
+try:
+    while True:
+        adc_value = light_sensor.value
+        
+        raw_value = int(adc_value * 1023)
+
+        print(f"ADC: {adc_value:.2f}, RAW: {raw_value}")
+        
+        sleep(0.5)
+except KeyboardInterrupt:
+    print("the end")


### PR DESCRIPTION
라즈베리파이5에 MCP3008(ADC) 달아서 ADC에 풀다운으로 저항 연결(전압분배기능) adafruit계열 라이브러리 설치해도 gpio핀을 입력받지 못하는 오류가 계속 발생->gpiozero 모듈 사용(기본적으로 설치되어 있음) 로컬에서도 바로 사용 가능